### PR TITLE
kaldi-trunk module using https instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kaldi-trunk"]
   path = kaldi-trunk
-  url = git@github.com:kaldi-asr/kaldi.git
+  url = https://github.com/kaldi-asr/kaldi.git


### PR DESCRIPTION
Recursive cloning fails for users without push access.